### PR TITLE
feat: 배송담당자 생성

### DIFF
--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':common') // 공통 모듈
     runtimeOnly 'org.postgresql:postgresql' // postgres
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa' // jpa
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0' // env
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/application/service/DeliveryRouteService.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/application/service/DeliveryRouteService.java
@@ -38,6 +38,11 @@ public class DeliveryRouteService {
 
         List<DeliveryRoute> routes = new ArrayList<>();
         for(HubRouteInfo hubRouteInfo : hubRoutes){
+            UUID deliveryDriveId = hubRouteInfo.deliveryDriverId();
+            if(deliveryDriveId == null) {
+                deliveryDriveId = addDeliveryDriver();
+            }
+
             DeliveryRoute route = DeliveryRoute.createDeliveryRoute(
                     hubRouteInfo.sequence(),
                     hubRouteInfo.startHubId(),
@@ -51,6 +56,12 @@ public class DeliveryRouteService {
         }
 
         return routes;
+    }
+
+    private UUID addDeliveryDriver() {
+        // TODO : 배송 기사 추가
+
+        return null;
     }
 
 

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/application/service/DeliveryDriverService.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/application/service/DeliveryDriverService.java
@@ -45,7 +45,6 @@ public class DeliveryDriverService {
         );
 
         deliveryDriverJpaRepository.save(driver);
-
     }
 
     public UUID addHubDeliveryDriver(UUID fromHubId) {

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/application/service/DeliveryDriverService.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/application/service/DeliveryDriverService.java
@@ -1,0 +1,58 @@
+package com.mcargo.deliveryservice.user.application.service;
+
+import com.mcargo.deliveryservice.user.domain.model.DeliveryDriver;
+import com.mcargo.deliveryservice.user.domain.model.DeliveryDriverNumberSeq;
+import com.mcargo.deliveryservice.user.domain.model.DeliveryDriverType;
+import com.mcargo.deliveryservice.user.infrastructure.repository.DeliveryDriverJpaRepository;
+import com.mcargo.deliveryservice.user.infrastructure.repository.DeliveryDriverNumberSeqJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryDriverService {
+
+    DeliveryDriverJpaRepository deliveryDriverJpaRepository;
+    DeliveryDriverNumberSeqJpaRepository deliveryDriverNumberSeqJpaRepository;
+
+    /**
+     * 배송 담당자 생성
+     */
+    public void createDeliveryDriver(Long userId, DeliveryDriverType deliveryDriverType) {
+        // TODO : 사용자 조회
+
+        UUID hubId = null;
+        // 업체 배송 담당자: 허브별 시퀀스 / 허브 배송 담당자 : hubId = null
+        if(deliveryDriverType == DeliveryDriverType.COMPANY_DRIVER) {
+            hubId = UUID.randomUUID();
+        }
+
+
+        DeliveryDriverNumberSeq seq =  deliveryDriverNumberSeqJpaRepository
+                .findByDeliveryDriverTypeAndHubId(deliveryDriverType, hubId)
+                .orElseThrow(() -> new RuntimeException("Delivery Driver Number Not Found"));
+
+        Integer nextNumber = seq.getNextNumber();
+
+        seq.increse();
+
+        DeliveryDriver driver = DeliveryDriver.createDeliveryDriver(
+                userId,
+                deliveryDriverType,
+                nextNumber
+        );
+
+        deliveryDriverJpaRepository.save(driver);
+
+    }
+
+    public UUID addHubDeliveryDriver(UUID fromHubId) {
+        // 해당 허브 사용자 중 배송 가능한 사용자 찾기
+
+        // 해당 사용자 중 우선순위가 가장 높은 사람 return
+
+        return null;
+    }
+}

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriver.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriver.java
@@ -1,0 +1,39 @@
+package com.mcargo.deliveryservice.user.domain.model;
+
+import com.mcargo.common.entity.BaseEntity;
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_delivery_driver")
+public class DeliveryDriver extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="delivery_driver_id", updatable = false, nullable = false)
+    private UUID deliveryDriverId;
+
+    // TODO : 사용자 테이블과 연관관계 추가
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeliveryDriverType deliveryDriverType;
+
+    @Column(nullable = false)
+    private int deliveryDriverSeq;
+//    private boolean isAvailable;
+
+
+    public static DeliveryDriver createDeliveryDriver(Long userId,
+                                                      DeliveryDriverType deliveryDriverType,
+                                                      int deliveryDriverSeq) {
+
+        DeliveryDriver deliveryDriver = new DeliveryDriver();
+        deliveryDriver.userId = userId;
+        deliveryDriver.deliveryDriverType = deliveryDriverType;
+        deliveryDriver.deliveryDriverSeq = deliveryDriverSeq;
+
+        return deliveryDriver;
+    }
+}

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriverNumberSeq.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriverNumberSeq.java
@@ -1,0 +1,47 @@
+package com.mcargo.deliveryservice.user.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "p_delivery_driver_number_seq")
+public class DeliveryDriverNumberSeq {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "delivery_driver_seq_id", nullable = false)
+    private UUID deliveryDriverSeqId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeliveryDriverType deliveryDriverType;
+
+    // 허브 배송 담당자는 null
+    private UUID hubId;
+
+    @Column(nullable = false)
+    private Integer nextNumber;
+
+    public void increse() {
+        this.nextNumber++;
+    }
+}
+
+/*
+시퀀스 초기 데이터 예시
+
+-- 전체 허브 공용 허브담당자 번호 (1~10)
+INSERT INTO delivery_driver_number_seq (delivery_driver_type, hub_id, next_number)
+VALUES ('HUB_DRIVER', NULL, 1);
+
+-- A 허브 업체담당자 번호 (1~10)
+INSERT INTO delivery_driver_number_seq (delivery_driver_type, hub_id, next_number)
+VALUES ('COMPANY_DRIVER', 1, 1);  -- 1번 허브라고 가정
+
+-- B 허브 업체담당자 번호 (1~10)
+INSERT INTO delivery_driver_number_seq (delivery_driver_type, hub_id, next_number)
+VALUES ('COMPANY_DRIVER', 2, 1);
+
+ */

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriverNumberSeq.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriverNumberSeq.java
@@ -27,6 +27,22 @@ public class DeliveryDriverNumberSeq {
     public void increse() {
         this.nextNumber++;
     }
+
+    public DeliveryDriverNumberSeq() {}
+
+    public DeliveryDriverNumberSeq(DeliveryDriverType deliveryDriverType, UUID hubId, Integer nextNumber) {
+        this.deliveryDriverType = deliveryDriverType;
+        this.hubId = hubId;
+        this.nextNumber = nextNumber;
+    }
+
+    public static DeliveryDriverNumberSeq createHubDriver() {
+        return new DeliveryDriverNumberSeq(DeliveryDriverType.HUB_DRIVER, null, 1);
+    }
+
+    public static DeliveryDriverNumberSeq createCompanyDriver(UUID hubId) {
+        return new DeliveryDriverNumberSeq(DeliveryDriverType.COMPANY_DRIVER, hubId, 1);
+    }
 }
 
 /*

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriverType.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/domain/model/DeliveryDriverType.java
@@ -1,0 +1,12 @@
+package com.mcargo.deliveryservice.user.domain.model;
+
+public enum DeliveryDriverType {
+    HUB_DRIVER("허브 배송 담당자"),
+    COMPANY_DRIVER("업체 배송 담당자");
+
+    private final String description;
+
+    DeliveryDriverType(String description) {
+        this.description = description;
+    }
+}

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/infrastructure/repository/DeliveryDriverJpaRepository.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/infrastructure/repository/DeliveryDriverJpaRepository.java
@@ -1,0 +1,9 @@
+package com.mcargo.deliveryservice.user.infrastructure.repository;
+
+import com.mcargo.deliveryservice.user.domain.model.DeliveryDriver;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface DeliveryDriverJpaRepository extends JpaRepository<DeliveryDriver, UUID> {
+}

--- a/delivery-service/src/main/java/com/mcargo/deliveryservice/user/infrastructure/repository/DeliveryDriverNumberSeqJpaRepository.java
+++ b/delivery-service/src/main/java/com/mcargo/deliveryservice/user/infrastructure/repository/DeliveryDriverNumberSeqJpaRepository.java
@@ -1,0 +1,18 @@
+package com.mcargo.deliveryservice.user.infrastructure.repository;
+
+import com.mcargo.deliveryservice.user.domain.model.DeliveryDriverNumberSeq;
+import com.mcargo.deliveryservice.user.domain.model.DeliveryDriverType;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryDriverNumberSeqJpaRepository extends JpaRepository<DeliveryDriverNumberSeq, UUID> {
+
+    // 트랜잭션 처리 중 다른 트랜잭션에서 읽기/쓰기 불가 (FOR UPDATE)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<DeliveryDriverNumberSeq> findByDeliveryDriverTypeAndHubId(DeliveryDriverType deliveryDriverType, UUID hubId);
+
+}

--- a/delivery-service/src/main/resources/application.yml
+++ b/delivery-service/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name: delivery-service
   datasource:
-    url: jdbc:postgresql://localhost:5432/mcargo
-    username: postgres
-    password: 1234
+    url: ${DELIVERY_DB_URL}
+    username: ${DELIVERY_DB_USERNAME}
+    password: ${DELIVERY_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:


### PR DESCRIPTION
## 🔘Part 
- user

## 🔎 작업 내용 
- 배송 담당자 생성 로직 개발
  - 배송 담당자 생성 시 seq 테이블으로 배송 순번 지정 

## 🔧 앞으로의 과제 
- hub 생성 시 seq 테이블에 배송 담담자 지정을 위한 시퀀스 추가
- 도메인 분리 (현재 delivery 도메인 하위에 임시로 만들어두었습니다.)
- 배송 담당자 지정 로직 작성(현재 비어있음)

## ➕ 이슈 링크 
- #이슈번호
